### PR TITLE
Test lazy imports in __init__

### DIFF
--- a/earthdaily/earthone/__init__.py
+++ b/earthdaily/earthone/__init__.py
@@ -45,17 +45,22 @@ try:
 except PackageNotFoundError:
     from earthdaily.earthone.core.client import __version__
 
-from earthdaily.earthone import auth
-from earthdaily.earthone import config
-from earthdaily.earthone import exceptions
-from earthdaily.earthone import geo
-from earthdaily.earthone import utils
-from earthdaily.earthone import catalog
-from earthdaily.earthone import compute
-from earthdaily.earthone import vector
+from earthdaily.earthone import auth, config, exceptions, geo, utils
 
 select_env = config.select_env
 get_settings = config.get_settings
+
+_LAZY_SUBMODULES = {"catalog", "compute", "vector"}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SUBMODULES:
+        import importlib
+
+        module = importlib.import_module(f"earthdaily.earthone.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __author__ = "EarthDaily"
 

--- a/earthdaily/earthone/__init__.py
+++ b/earthdaily/earthone/__init__.py
@@ -62,6 +62,10 @@ def __getattr__(name: str):
         return module
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
+
+def __dir__():
+    return __all__
+
 __author__ = "EarthDaily"
 
 __all__ = [

--- a/earthdaily/earthone/__init__.py
+++ b/earthdaily/earthone/__init__.py
@@ -45,12 +45,12 @@ try:
 except PackageNotFoundError:
     from earthdaily.earthone.core.client import __version__
 
-from earthdaily.earthone import auth, config, exceptions, geo, utils
+from earthdaily.earthone import config
 
 select_env = config.select_env
 get_settings = config.get_settings
 
-_LAZY_SUBMODULES = {"catalog", "compute", "vector"}
+_LAZY_SUBMODULES = {"auth", "catalog", "compute", "exceptions", "geo", "utils", "vector"}
 
 
 def __getattr__(name: str):

--- a/earthdaily/earthone/core/client/version.py
+++ b/earthdaily/earthone/core/client/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "6.0.1"
+__version__ = "6.0.2"


### PR DESCRIPTION
**Problem**
Importing `earthdaily.earthone` (or any of its eagerly-loaded sub-packages such as `auth`) triggered the immediate loading of all sub-packages. The `vector` sub-package transitively imports `geopandas, pandas, and shapely` at module level — all of which are expensive to initialise. This caused significant cold-start latency in environments that only need a lightweight sub-package (e.g. a Lambda function using only auth for token management).

**Change**
All sub-packages except config are now imported lazily using the PEP 562 module-level `__getattr__` mechanism. They are loaded on first access rather than at package initialisation time.

config remains eagerly imported as it is required at module load time to assign the top-level select_env and get_settings helpers.

A module-level `__dir__` has also been added, returning `__all__,` so that IDE tab-completion and `dir()` introspection continue to show lazy sub-packages even before they have been accessed.

**Options considered**
I considered adding a `preload()` function to allow opt-in eager loading but doesn't seem to be a common practice. users can achieve the same result with standard Python:
```
import earthdaily.earthone.catalog
import earthdaily.earthone.compute
import earthdaily.earthone.vector
```
Adding a named function would expand the public API surface for no meaningful benefit.